### PR TITLE
Configurable library ignore paths by environment varable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,22 @@ end
 - mecab
 - dictionary for mecab (such as mecab-ipadic, mecab-naist-jdic, and so on)
 
-If you don't install mecab and libmecab yet, MeCab.jl will install mecab, libmecab and mecab-ipadic under unix-like environment.
+If you don't install mecab and libmecab yet, MeCab.jl will install mecab, libmecab and mecab-ipadic that are confirmed to work with MeCab.jl under unix-like environment.
+
+Note that by default, MeCab.jl will try to find system-installed libmecab (e.g. /usr/lib/libmecab.dylib). If you have already libmecab installed, this might cause library or dictionary incompatibility that MeCab.jl assumes. If you have any problem with system-installed ones, please try to ignore them and rebuild MeCab.jl by:
+
+```jl
+julia> ENV["MECABJL_LIBRARY_IGNORE_PATH"] = "/usr/lib:/usr/local/lib" # depends on your environment
+julia> Pkg.build("MeCab")
+```
+
+The libmecab library path will be stored in `MeCab.libmecab` after loading MeCab.jl. The library path should look like for example:
+
+```jl
+julia> using MeCab
+julia> MeCab.libmecab
+"$your_home_dir_path/.julia/v0.4/MeCab/deps/usr/lib/libmecab.dylib"
+```
 
 ## Credits
 MeCab.jl is created by Michiaki Ariga


### PR DESCRIPTION
### まとめ

 MeCab.jlと動作する保証がない libmecab（e.g. /usr/lib/libmecab.dylib）をMeCab.jlが使おうとするのを防ぐために、libmecab の ignore pathを設定できるように、修正しました。 簡単な使い方は、以下のとおりです。

```jl
julia> ENV["MECABJL_LIBRARY_IGNORE_PATH"] = "/usr/lib:/usr/local/lib"
julia> Pkg.build("MeCab")
```

### 問題

システムにlibmecabがインストールされていると、MeCab.jlはデフォルトでシステムのlibmecabを使おうとしますが、MeCab.jlと互換性のないlibmecab or 辞書である or そもそも辞書がないなどの場合に、MeCab.jl が動かないといったことがおきます。少なくとも僕のローカル（osx 10.10）では、/usr/lib/libmecab.jl を使おうとすると動きませんでした（もちろん人によりますが、あり得ることではあります）。

### 解決法

BinDepsでインストールするlibmecabと辞書は、MeCab.jlと互換性があることはCIが保証しているので、その保証されたlibmecabと辞書をユーザ指定で使えるようにしました（正確には、特定のパスのライブラリをignoreする実装をしました）

https://juliatokyo.slack.com/archives/general/p1451023779000084 この辺のやりとりを受けての修正です。おそらくですが、 @sorami さんが遭遇した問題も、この修正で回避可能じゃなかなと思っています。

README に注意事項を追記しておきました。
